### PR TITLE
Publish hot fix - gradle build faster

### DIFF
--- a/PaymentService/payment/build.gradle
+++ b/PaymentService/payment/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	runtimeOnly 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	developmentOnly "org.springframework.boot:spring-boot-devtools"
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/PaymentService/payment/gradle.properties
+++ b/PaymentService/payment/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=true


### PR DESCRIPTION
최초 빌드 시 gradle build 될 떄 너무 오랜 시간 걸리는 문제 완화
gradle.properties 파일 생성 후 org.gradle.daemon=true 코드 추가 하여 build 시간 단축