### PR TITLE
Feature/payment Fix payment API for mypage

### DIFF
--- a/PaymentService/payment/src/main/java/org/payment/controller/PaymentApiController.java
+++ b/PaymentService/payment/src/main/java/org/payment/controller/PaymentApiController.java
@@ -1,16 +1,20 @@
 package org.payment.controller;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import lombok.RequiredArgsConstructor;
+import net.bytebuddy.asm.Advice;
 import org.payment.DTO.PaymentRequestDTO;
 import org.payment.DTO.PaymentResponseDTO;
 import org.payment.entity.Payment;
 import org.payment.service.PaymentService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
 
 @RestController
 @RequestMapping({"/payment"})
@@ -29,30 +33,55 @@ public class PaymentApiController {
         return ResponseEntity.ok(paymentService.findAll());
     }
     // 소비자 결제 내역 조회
-    @GetMapping("/consumer/{consumerId}")
-    public ResponseEntity<List<Payment>> findByConsumerId(@PathVariable Long consumerId) {
+    @GetMapping("/consumer")
+    public ResponseEntity<List<Payment>> findByConsumerId(@RequestParam Long consumerId) {
         return ResponseEntity.ok(paymentService.findByConsumerId(consumerId));
     }
     // 판매자 결제 내역 조회
-    @GetMapping("/seller/{sellerId}")
-    public ResponseEntity<List<Payment>> findBySellerId(@PathVariable Long sellerId){
+    @GetMapping("/seller/")
+    public ResponseEntity<List<Payment>> findBySellerId(@RequestParam Long sellerId){
         return ResponseEntity.ok(paymentService.findBySellerId(sellerId));
     }
-    // 소비자의 구독중인 상품
-    @GetMapping("/consumer/{consumerId}/sub")
-    public ResponseEntity<List<Payment>> findByConsumerIdAndExpirationDateGreaterThan(@PathVariable Long consumerId){
-        return ResponseEntity.ok(paymentService.findByConsumerIdAndExpirationDateGreaterThan(consumerId, LocalDate.now()));
+    @GetMapping("/consumer/mypage")
+    public List<Long> sub_product(@RequestParam Long consumerId, String type){
+        switch (type) {
+            // 소비자의 구독중인 상품
+            default: {
+                List<Payment> resultList = paymentService.sub_product(consumerId, LocalDate.now());
+                List<Long> productList = new ArrayList<>();
+                for (Payment payment : resultList) {
+                    productList.add(payment.getProductId());
+                }
+                return productList;
+            }
+            // 소비자의 오늘 만료되는 구독상품
+            case "now": {
+                List<Payment> resultList = paymentService.exp_today(consumerId, LocalDate.now());
+                List<Long> productList = new ArrayList<>();
+                for (Payment payment : resultList) {
+                    productList.add(payment.getProductId());
+                }
+                return productList;
+            }
+            // 소비자의 만료된 구독상품들
+            case "exp": {
+                List<Payment> resultList = paymentService.exp_product(consumerId, LocalDate.now());
+                List<Long> productList = new ArrayList<>();
+                for (Payment payment : resultList) {
+                    productList.add(payment.getProductId());
+                }
+                return productList;
+            }
+            // 소비자의 상품중 만료가 7일 전인 상품들
+            case "7ago": {
+                List<Payment> resultList = paymentService.exp_7ago(consumerId, LocalDate.now().plusDays(1), LocalDate.now().plusWeeks(1));
+                List<Long> productList = new ArrayList<>();
+                for (Payment payment : resultList) {
+                    productList.add(payment.getProductId());
+                }
+                return productList;
+            }
+        }
     }
-    // 소비자의 오늘 만료되는 구독상품
-    @GetMapping("/consumer/{consumerId}/now")
-    public ResponseEntity<List<Payment>> findByConsumerIdAndExpirationDateIs(@PathVariable Long consumerId){
-        return ResponseEntity.ok(paymentService.findByConsumerIdAndExpirationDateIs(consumerId, LocalDate.now()));
-    }
-    // 소비자의 만료된 구독상품들
-    @GetMapping("/consumer/{consumerId}/exp")
-    public ResponseEntity<List<Payment>> findByConsumerIdAndExpirationDateLessThan(@PathVariable Long consumerId){
-        return ResponseEntity.ok(paymentService.findByConsumerIdAndExpirationDateLessThan(consumerId, LocalDate.now()));
-    }
-    // 소비자의 상품중 만료가 7일 전인 상품들
 
 }

--- a/PaymentService/payment/src/main/java/org/payment/entity/Payment.java
+++ b/PaymentService/payment/src/main/java/org/payment/entity/Payment.java
@@ -15,8 +15,7 @@ public class Payment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column
-    private Long productId;
+   private Long productId;
     @Column
     private Integer price;
     @Column

--- a/PaymentService/payment/src/main/java/org/payment/entity/PaymentRepository.java
+++ b/PaymentService/payment/src/main/java/org/payment/entity/PaymentRepository.java
@@ -20,5 +20,5 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     List<Payment> findByConsumerIdAndExpirationDateGreaterThan(Long consumerId, LocalDate localDate);
     List<Payment> findByConsumerIdAndExpirationDateIs(Long consumerId, LocalDate localDate);
     List<Payment> findByConsumerIdAndExpirationDateLessThan(Long consumerId, LocalDate localDate);
-
+    List<Payment> findByConsumerIdAndExpirationDateBetween(Long consumerId, LocalDate now, LocalDate ago);
 }

--- a/PaymentService/payment/src/main/java/org/payment/service/PaymentService.java
+++ b/PaymentService/payment/src/main/java/org/payment/service/PaymentService.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.client.RestTemplate;
 
 @Service
 @RequiredArgsConstructor
@@ -40,21 +41,21 @@ public class PaymentService {
         return paymentRepository.findBySellerId(sellerId);
     }
     @Transactional
-    public List<Payment> findByConsumerIdAndExpirationDateGreaterThan(Long consumerId, LocalDate localDate){
+    public List<Payment> sub_product(Long consumerId, LocalDate localDate){
         return paymentRepository.findByConsumerIdAndExpirationDateGreaterThan(consumerId, localDate);
     }
     @Transactional
-    public List<Payment> findByConsumerIdAndExpirationDateIs(Long consumerId, LocalDate localDate){
+    public List<Payment> exp_today(Long consumerId, LocalDate localDate){
         return paymentRepository.findByConsumerIdAndExpirationDateIs(consumerId, localDate);
     }
     @Transactional
-    public List<Payment> findByConsumerIdAndExpirationDateLessThan(Long consumerId, LocalDate localDate){
+    public List<Payment> exp_product(Long consumerId, LocalDate localDate){
         return paymentRepository.findByConsumerIdAndExpirationDateLessThan(consumerId, localDate);
     }
-
-
-
-
+    @Transactional
+    public List<Payment> exp_7ago(Long consumerId, LocalDate now, LocalDate ago){
+        return paymentRepository.findByConsumerIdAndExpirationDateBetween(consumerId, now, ago);
+    }
 
 
 }


### PR DESCRIPTION
## 변경사항
#### 1. Request 호출 URL 한개로 통합 -> payment/consumer/mypage
#### 2. 호출 시 2개의 파라미터 전달 필요(RequestParam 으로 받기 떄문에 form 태그로 주거나 header에 첨부 필요)
consumerId : Long
type : String

#### 3. type 에 해당 문자열들을 줌으로써 각각 조회할 수 있는 것들이 달라짐
default(type 값을 안주거나 틀린 값을 줄 경우): 현재 구독중인 상품 ID 리스트
"now" :  오늘 만료되는 상품 ID 리스트
"exp" : 만료된 상품 ID 리스트
"7ago" : 만료까지 7일 남은 상품 ID 리스트(당일 만료는 포함되지 않음)

[예시]
![image](https://user-images.githubusercontent.com/87006912/202663535-8c22f156-dde1-459d-974f-14802e1e207f.png)
