### PR TITLE
Feature/payment Fix payment API for mypage - exp list

### DIFF
--- a/PaymentService/payment/src/main/java/org/payment/controller/PaymentApiController.java
+++ b/PaymentService/payment/src/main/java/org/payment/controller/PaymentApiController.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import net.bytebuddy.asm.Advice;
@@ -65,12 +66,19 @@ public class PaymentApiController {
             }
             // 소비자의 만료된 구독상품들
             case "exp": {
-                List<Payment> resultList = paymentService.exp_product(consumerId, LocalDate.now());
+                List<Payment> expList = paymentService.exp_product(consumerId, LocalDate.now());
                 List<Long> productList = new ArrayList<>();
-                for (Payment payment : resultList) {
+                for (Payment payment : expList) {
                     productList.add(payment.getProductId());
                 }
-                return productList;
+                // 증복제거
+                List<Long> resultList = productList.stream().distinct().collect(Collectors.toList());
+                // 현재 구독중인 상품 리스트 제거
+                List<Payment> subList = paymentService.sub_product(consumerId, LocalDate.now());
+                for (Payment payment : subList){
+                    resultList.remove(payment.getProductId());
+                }
+                return resultList;
             }
             // 소비자의 상품중 만료가 7일 전인 상품들
             case "7ago": {


### PR DESCRIPTION
## 변경사항
#### 구독 만료된 상품 리스트 출력 방식 변경됨
- 리스트 내의 중복 상품 ID 제거
- 현재 구독중인 상품 ID 제거
- 즉 조회 시 순수하게 만료된 상품들의 ID 리스트만 깔끔하게 return 되도록 변경했습니다.

[예시]
2022-11-18 기준 테스트  
- 3이 총 3개 이나 중복으로 출력 되지 않음
- exp 모든값을 가져오면 3, 4 가 리턴되어야 하나 3이 최근에 다시 구독되어 있으므로 4만 리턴
![image](https://user-images.githubusercontent.com/87006912/202672487-5bd84c4c-4891-42c0-ba9f-281cd14afa74.png)
![image](https://user-images.githubusercontent.com/87006912/202672300-e8d3375a-b0ac-4e0b-94e4-ccffec514882.png)

