### PR TITLE
Add spring cron for auto create payment & spring webplux(webclient) for increase subscriber count

### DIFF
--- a/PaymentService/payment/build.gradle
+++ b/PaymentService/payment/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16'
 	implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.23'
 	implementation 'io.github.cdimascio:dotenv-java:2.2.4'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux:2.7.5'
 	runtimeOnly 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/PaymentService/payment/src/main/java/org/payment/PaymentApplication.java
+++ b/PaymentService/payment/src/main/java/org/payment/PaymentApplication.java
@@ -3,9 +3,11 @@ package org.payment;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 @SpringBootApplication
+@EnableScheduling
 public class PaymentApplication {
 
 	public static void main(String[] args) {

--- a/PaymentService/payment/src/main/java/org/payment/controller/PaymentApiController.java
+++ b/PaymentService/payment/src/main/java/org/payment/controller/PaymentApiController.java
@@ -1,16 +1,27 @@
 package org.payment.controller;
 
+import java.net.URI;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import org.payment.DTO.PaymentRequestDTO;
 import org.payment.entity.Payment;
 import org.payment.service.PaymentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.reactive.function.BodyInserter;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 @RestController
 @RequestMapping({"/payment"})
@@ -20,12 +31,24 @@ public class PaymentApiController {
 
     // 결제 내역 생성
     @PostMapping
-    public ResponseEntity<Payment> save(@RequestBody Payment params) {
-        return ResponseEntity.ok(paymentService.save(params));
+    public ResponseEntity<?> save(@RequestBody Payment params) {
+        Payment payment = paymentService.save(params);
+        // webclient
+        WebClient webClient = WebClient.create("localhost:8000");
+        webClient.put()
+                .body(BodyInserters.fromFormData("productId", "1"))
+                .retrieve()
+                .bodyToMono(String.class);
+        return new ResponseEntity<>("결제 성공",HttpStatus.OK);
     }
+//    // PRG pattern
+//    @GetMapping("/success")
+//    public ResponseEntity<?> success(){
+//        return  new ResponseEntity<>("201", HttpStatus.CREATED);
+//    }
     // 전체 결제 내역 조회
     @GetMapping
-    public ResponseEntity<List<Payment>> findAll() {
+    public ResponseEntity<?> findAll() {
         return ResponseEntity.ok(paymentService.findAll());
     }
     // 소비자 결제 내역 조회

--- a/PaymentService/payment/src/main/java/org/payment/entity/PaymentRepository.java
+++ b/PaymentService/payment/src/main/java/org/payment/entity/PaymentRepository.java
@@ -18,4 +18,5 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     List<Payment> findByConsumerIdAndExpirationDateIs(Long consumerId, LocalDate localDate);
     List<Payment> findByConsumerIdAndExpirationDateLessThan(Long consumerId, LocalDate localDate);
     List<Payment> findByConsumerIdAndExpirationDateBetween(Long consumerId, LocalDate now, LocalDate ago);
+    List<Payment> findByPaymentDueDate(LocalDate localDate);
 }

--- a/PaymentService/payment/src/main/java/org/payment/service/PaymentService.java
+++ b/PaymentService/payment/src/main/java/org/payment/service/PaymentService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.payment.DTO.PaymentRequestDTO;
 import org.payment.entity.Payment;
 import org.payment.entity.PaymentRepository;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -47,6 +48,27 @@ public class PaymentService {
     public List<Payment> exp_7ago(Long consumerId, LocalDate now, LocalDate ago){
         return paymentRepository.findByConsumerIdAndExpirationDateBetween(consumerId, now, ago);
     }
-
+    // 가상 정기 결제
+    // 실결제는 X , 일정 시간 paymentDueDate 조회하여
+    // 날짜 한달 뒤인 새로운 payment 자동 생성
+    @Scheduled(cron = "0 0 11 * * *") // 매일 오전 11시 마다
+    public void scheduleRun(){
+        System.out.println("Run method per 30sec");
+        List<Payment> paymentList = paymentRepository.findByPaymentDueDate(LocalDate.now());
+        for(Payment data : paymentList){
+            System.out.println("ID " + data.getId());
+            Payment entity = Payment.builder()
+                    .price(data.getPrice())
+                    .productId(data.getProductId())
+                    .consumerId(data.getConsumerId())
+                    .sellerId(data.getSellerId())
+                    .subscriptionDate(LocalDate.now())
+                    .expirationDate(LocalDate.now().plusMonths(1))
+                    .paymentDueDate(LocalDate.now().plusMonths(1))
+                    .build();
+            Payment newPayment = paymentRepository.save(entity);
+            System.out.println("ID " + newPayment.getId());
+        }
+    }
 
 }

--- a/PaymentService/payment/src/main/resources/application.properties
+++ b/PaymentService/payment/src/main/resources/application.properties
@@ -12,3 +12,5 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.open-in-view=false
 spring.jpa.generate-ddl=true
 spring.jpa.hibernate.ddl-auto=validate
+
+# spring setting


### PR DESCRIPTION
## 추가 내용
1. Spring cron 을 이용한 가상 정기 결제 추가
매일 오전 11시 마다 payment_due_date 와 오늘의 값이 같은 payment 의 값을 조회한 뒤
해당 payment의 date 값들에 한달 더해 새로운  payment 생성됨 (가상 정기 결제)

2. Spring webflux(webclient) 를 추가하여 다른 외부 API와 통신 (결제 성공 => 해당 상품의 구독자 수 증가 API 호출)